### PR TITLE
WE-3638: Upload files to Azure

### DIFF
--- a/data_transfer/src/basic.partial.application.schema.json
+++ b/data_transfer/src/basic.partial.application.schema.json
@@ -42,7 +42,27 @@
           "type": "string"
         }
       }
+    },
+    "files": {
+      "type": "array",
+      "description": "Files uploaded as part of the application",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The blobname returned when saving the file to Dynamics"
+          },
+          "filetype": {
+            "type": "string",
+            "description": "What the file is (eg. air dispersion modelling report)"
+          },
+          "filename": {
+            "type": "string",
+            "description": "The original filename of the uploaded file"
+          }
+        }
+      }
     }
   }
 }
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,8 @@ services:
       - ${PWD}/poc_flow_map_front_end/src:/home/node/src
       # use a volume to persist node_modules, prevents leakage to host
       - web_flow_map_node_modules:/home/node/node_modules
+    env_file:
+      - ${PWD}/poc_flow_map_front_end/.env
     environment:
       HOST_NAME: "web.flow"
       LOG_LEVEL: "debug"

--- a/poc_flow_map_front_end/src/basic.partial.application.schema.json
+++ b/poc_flow_map_front_end/src/basic.partial.application.schema.json
@@ -42,7 +42,27 @@
           "type": "string"
         }
       }
+    },
+    "files": {
+      "type": "array",
+      "description": "Files uploaded as part of the application",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The blobname returned when saving the file to Dynamics"
+          },
+          "filetype": {
+            "type": "string",
+            "description": "What the file is (eg. air dispersion modelling report)"
+          },
+          "filename": {
+            "type": "string",
+            "description": "The original filename of the uploaded file"
+          }
+        }
+      }
     }
   }
 }
-

--- a/poc_flow_map_front_end/src/server/modules/address/address-entry.njk
+++ b/poc_flow_map_front_end/src/server/modules/address/address-entry.njk
@@ -2,18 +2,8 @@
 
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
-{%- from "moj/components/banner/macro.njk" import mojBanner -%}
-
-{% set bannerHtml %}
-  <h2 class="govuk-heading-m">This is an MOJ component in Nunjucks</h2>
-{% endset %}
 
 {% block formContent %}
-
-{{ mojBanner({
-  type: 'information',
-  html: bannerHtml
-}) }} 
 
 {% call govukFieldset({
   legend: {

--- a/poc_flow_map_front_end/src/server/modules/form-layout.njk
+++ b/poc_flow_map_front_end/src/server/modules/form-layout.njk
@@ -19,7 +19,7 @@
         </h1>
       {% endif %}
 
-      <form method="post" autocomplete="off" novalidate>
+      <form method="post" autocomplete="off" novalidate {% block formOptions %}{% endblock %}>
         {% block formContent %}{% endblock %}
 
         {% block continueButton %}

--- a/poc_flow_map_front_end/src/server/modules/map.yml
+++ b/poc_flow_map_front_end/src/server/modules/map.yml
@@ -7,6 +7,12 @@ home:
 permit:
   path: "/permit"
   module: permit
+  next: upload
+
+
+upload:
+  path: "/upload"
+  module: upload
   next: address
 
 

--- a/poc_flow_map_front_end/src/server/modules/permit/permit-type.view.js
+++ b/poc_flow_map_front_end/src/server/modules/permit/permit-type.view.js
@@ -12,11 +12,6 @@ const items = reference.map(({ id, label }) => {
 
 const components = [
   {
-    type: 'MojBanner',
-    bannerType: 'information',
-    content: '<h2 class="govuk-heading-m">This is an MOJ Frontend component</h2>'
-  },
-  {
     type: 'RadiosField',
     name: 'permitType',
     title: 'Select the type of permit you want to apply for',

--- a/poc_flow_map_front_end/src/server/modules/transfer/transfer-data.route.js
+++ b/poc_flow_map_front_end/src/server/modules/transfer/transfer-data.route.js
@@ -1,10 +1,9 @@
 const Boom = require('@hapi/boom')
-const { BlobServiceClient } = require('@azure/storage-blob')
-const Ajv = require('ajv')
 const { logger } = require('defra-logging-facade')
-const { AZURE_STORAGE_CONNECTION_STRING, BLOB_CONTAINER_NAME } = process.env
 const Application = require('../../dao/application.js')
 const schema = require('../../../basic.partial.application.schema.json')
+
+const { sendToDynamics, validateMessage } = require('../../utils/transfer')
 
 module.exports = {
   method: 'GET',
@@ -18,32 +17,17 @@ module.exports = {
   }
 }
 
-async function sendToDynamics (obj, label) {
-  const content = JSON.stringify(obj)
-
-  const blobServiceClient = await BlobServiceClient.fromConnectionString(AZURE_STORAGE_CONNECTION_STRING)
-  const containerClient = blobServiceClient.getContainerClient(BLOB_CONTAINER_NAME)
-  const blobName = label + new Date().getTime()
-  const blockBlobClient = containerClient.getBlockBlobClient(blobName)
-  const uploadResult = await blockBlobClient.upload(content, content.length)
-  logger.info(`Upload block blob successfully: ${uploadResult.requestId}`)
-}
-
-function validateMessage (message) {
-  const ajv = new Ajv()
-  const validate = ajv.compile(schema)
-  return validate(message)
-}
-
 async function transferData (message) {
   try {
     logger.info('Validating message...')
-    if (validateMessage(message)) {
+    if (validateMessage(message, schema)) {
       logger.info('Message valid')
-      // await sendToDynamics(schema, 'schema')
+      // const schemaObj = JSON.stringify(schema)
+      // await sendToDynamics(schemaObj, 'schema')
       // logger.info('SUCCESS, SCHEMA SENT')
       logger.info('Sending message...')
-      await sendToDynamics(message, 'message')
+      const messageObj = JSON.stringify(message)
+      await sendToDynamics(messageObj, 'message')
       logger.info('Message sent')
       logger.info(message)
     } else {

--- a/poc_flow_map_front_end/src/server/modules/transfer/transfer-data.route.js
+++ b/poc_flow_map_front_end/src/server/modules/transfer/transfer-data.route.js
@@ -27,7 +27,9 @@ async function transferData (message) {
       // logger.info('SUCCESS, SCHEMA SENT')
       logger.info('Sending message...')
       const messageObj = JSON.stringify(message)
-      await sendToDynamics(messageObj, 'message')
+      const result = await sendToDynamics(messageObj, 'message')
+      logger.info('Result of send:')
+      logger.info(result)
       logger.info('Message sent')
       logger.info(message)
     } else {

--- a/poc_flow_map_front_end/src/server/modules/upload/upload.map.yml
+++ b/poc_flow_map_front_end/src/server/modules/upload/upload.map.yml
@@ -1,0 +1,6 @@
+
+upload:
+  title: Please upload a file
+  path: ""
+  route: upload.route
+  next: return

--- a/poc_flow_map_front_end/src/server/modules/upload/upload.njk
+++ b/poc_flow_map_front_end/src/server/modules/upload/upload.njk
@@ -1,0 +1,25 @@
+{% extends 'form-layout.njk' %}
+
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+
+{% block formContent %}
+
+{% call govukFieldset({
+  legend: {
+    text: pageHeading,
+    classes: "govuk-fieldset__legend--xl",
+    isPageHeading: true
+  } }) %}
+
+{{ govukFileUpload({
+  id: "upload-id",
+  name: "upload-name",
+  label: {
+    text: "Upload a file"
+  }
+}) }}
+
+{% endcall %}
+
+{% endblock %}

--- a/poc_flow_map_front_end/src/server/modules/upload/upload.njk
+++ b/poc_flow_map_front_end/src/server/modules/upload/upload.njk
@@ -3,6 +3,8 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 
+{% block formOptions %} enctype="multipart/form-data" {% endblock %}
+
 {% block formContent %}
 
 {% call govukFieldset({
@@ -13,8 +15,8 @@
   } }) %}
 
 {{ govukFileUpload({
-  id: "upload-id",
-  name: "upload-name",
+  id: "upload",
+  name: "upload",
   label: {
     text: "Upload a file"
   }

--- a/poc_flow_map_front_end/src/server/modules/upload/upload.route.js
+++ b/poc_flow_map_front_end/src/server/modules/upload/upload.route.js
@@ -2,33 +2,41 @@ const Application = require('../../dao/application')
 // const Joi = require('@hapi/joi')
 // const failWith = require('../../utils/validation')
 const view = 'upload/upload.njk'
+const { sendToDynamics } = require('../../utils/transfer')
+const { logger } = require('defra-logging-facade')
 
 module.exports = [{
   method: 'GET',
   handler: async function (request, h) {
-    // TODO: Get current uploaded files
-    return h.view(view, { pageHeading: 'Upload a file' })
+    // formOptions is set so we can pass through the required parameter for an upload form
+    return h.view(view, { pageHeading: 'Upload a file', formOptions: 'enctype="multipart/form-data"' })
   }
 }, {
   method: 'POST',
   handler: async function (request, h) {
-    console.log(request)
+    const { upload } = request.payload
+    const data = upload.read()
+    const sendResult = await sendToDynamics(data, 'file')
 
-    // TODO: use utils/transfer#sendToDynamics to send file to Dynamics
+    const { blobName: id } = sendResult
+    const filetype = 'POC demo file'
+    const { filename } = upload.hapi
 
-    // TODO: save Dynamics blobName to application, eg:
-    // {
-    //   files: [
-    //     { id: 'file blobName...'},
-    //     { id: 'file blobName...'}
-    //   ], etc...
-    // }
-    
-    // TODO: Loop back while user wants to upload more files
+    const files = [{ id, filetype, filename }]
+
+    await Application.update(request, { files })
+
+    // TODO: Allow multiple files and loop back while user wants to upload more files
+    // TODO: Change over to MOJ multi file upload component
 
     return h.continue
   },
+  // TODO: Maybe add some basic validation
   options: {
+    payload: {
+      parse: true,
+      output: 'stream',
+    }
     // validate: {
     //   payload: Joi.object({
     //     ...

--- a/poc_flow_map_front_end/src/server/modules/upload/upload.route.js
+++ b/poc_flow_map_front_end/src/server/modules/upload/upload.route.js
@@ -1,0 +1,28 @@
+const Application = require('../../dao/application')
+// const Joi = require('@hapi/joi')
+// const failWith = require('../../utils/validation')
+const view = 'upload/upload.njk'
+
+module.exports = [{
+  method: 'GET',
+  handler: async function (request, h) {
+    // TODO: Get current uploaded files
+    return h.view(view, { pageHeading: 'Upload a file' })
+  }
+}, {
+  method: 'POST',
+  handler: async function (request, h) {
+    console.log(request.payload)
+    return h.continue // TODO: Loop back while user wants to upload more files
+  },
+  options: {
+    // validate: {
+    //   payload: Joi.object({
+    //     ...
+    //   }),
+    //   failAction: failWith(view, {
+    //     ...
+    //   })
+    // }
+  }
+}]

--- a/poc_flow_map_front_end/src/server/modules/upload/upload.route.js
+++ b/poc_flow_map_front_end/src/server/modules/upload/upload.route.js
@@ -12,8 +12,21 @@ module.exports = [{
 }, {
   method: 'POST',
   handler: async function (request, h) {
-    console.log(request.payload)
-    return h.continue // TODO: Loop back while user wants to upload more files
+    console.log(request)
+
+    // TODO: use utils/transfer#sendToDynamics to send file to Dynamics
+
+    // TODO: save Dynamics blobName to application, eg:
+    // {
+    //   files: [
+    //     { id: 'file blobName...'},
+    //     { id: 'file blobName...'}
+    //   ], etc...
+    // }
+    
+    // TODO: Loop back while user wants to upload more files
+
+    return h.continue
   },
   options: {
     // validate: {

--- a/poc_flow_map_front_end/src/server/utils/transfer.js
+++ b/poc_flow_map_front_end/src/server/utils/transfer.js
@@ -11,6 +11,7 @@ async function sendToDynamics (content, label) {
   const blockBlobClient = containerClient.getBlockBlobClient(blobName)
   const uploadResult = await blockBlobClient.upload(content, content.length)
   logger.info(`Upload block blob successfully: ${uploadResult.requestId}`)
+  // TODO: return blobName
 }
 
 function validateMessage (message, schema) {

--- a/poc_flow_map_front_end/src/server/utils/transfer.js
+++ b/poc_flow_map_front_end/src/server/utils/transfer.js
@@ -11,7 +11,7 @@ async function sendToDynamics (content, label) {
   const blockBlobClient = containerClient.getBlockBlobClient(blobName)
   const uploadResult = await blockBlobClient.upload(content, content.length)
   logger.info(`Upload block blob successfully: ${uploadResult.requestId}`)
-  // TODO: return blobName
+  return { blobName, uploadResult }
 }
 
 function validateMessage (message, schema) {

--- a/poc_flow_map_front_end/src/server/utils/transfer.js
+++ b/poc_flow_map_front_end/src/server/utils/transfer.js
@@ -1,0 +1,22 @@
+const { BlobServiceClient } = require('@azure/storage-blob')
+const Ajv = require('ajv')
+const { logger } = require('defra-logging-facade')
+
+const { AZURE_STORAGE_CONNECTION_STRING, BLOB_CONTAINER_NAME } = process.env
+
+async function sendToDynamics (content, label) {
+  const blobServiceClient = await BlobServiceClient.fromConnectionString(AZURE_STORAGE_CONNECTION_STRING)
+  const containerClient = blobServiceClient.getContainerClient(BLOB_CONTAINER_NAME)
+  const blobName = label + new Date().getTime()
+  const blockBlobClient = containerClient.getBlockBlobClient(blobName)
+  const uploadResult = await blockBlobClient.upload(content, content.length)
+  logger.info(`Upload block blob successfully: ${uploadResult.requestId}`)
+}
+
+function validateMessage (message, schema) {
+  const ajv = new Ajv()
+  const validate = ajv.compile(schema)
+  return validate(message)
+}
+
+module.exports = { sendToDynamics, validateMessage }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WE-3638

The following changes have been made to `poc_flow_map_front_end`:

* File transfer functions have been moved into `src/server/utils/transfer.js`
* An upload screen is added after the standard rule category screen.
* The file is uploaded to Azure and a reference added to the application.
* An array of files has been added to the JSON schema.

I'm raising an early pull request for this to ensure it's in place for the demo on Wednesday morning. The following features aren't yet added:

* No validation is done just yet; if the user doesn't upload the file then a server error is raised.
* It moves straight on to the next screen when you upload a file. No notification is given, and the usual pattern (upload files until the user specifies they're done) is not used.
* Because of this, only one file is uploaded (although the JSON schema should support multiple files). This means that the standard GOV UK file upload component is used rather than the MOJ multi-file upload component.
* Nothing added to the docs for this just yet.

Work to resolve these can be done in a new branch during the next sprint.