### PR TITLE
Nodemon now correctly watches yml, yaml, njk files

### DIFF
--- a/poc_flow_map_front_end/bin/run_watch.sh
+++ b/poc_flow_map_front_end/bin/run_watch.sh
@@ -2,5 +2,5 @@
 
 set -euo pipefail
 
-nodemon -- watch $HOME/src/app -e js,html,yml,yaml,njk src/app.js
+nodemon -e js,html,yml,yaml,njk src/app.js -- watch $HOME/src/app 
 


### PR DESCRIPTION
It seems Nodemon is picky about the order you put some of the options. The list of extensions to monitor has been moved to the start of the options and it now correctly restarts when yml, yaml and njk files change.