### PR TITLE
Adds application, queryData and current route info to the 500 error

### DIFF
--- a/poc_flow_map_front_end/src/server/modules/error-layout.njk
+++ b/poc_flow_map_front_end/src/server/modules/error-layout.njk
@@ -13,6 +13,9 @@
                 <div class="defra-dev-errors">
                     <pre>Error: {{ devDetails | dump(2) | safe }}</pre>
                     <pre>{{ stack | safe }}</pre>
+                    <pre>QueryData: {{ queryData | dump(2) | safe }}</pre>
+                    <pre>Route: {{ route | dump(2) | safe }}</pre>
+                    <pre>Application: {{ application | dump(2) | safe }}</pre>
                 </div>
             {% endif %}
         </div>


### PR DESCRIPTION
This only displays when NODE_ENV is 'development'.  