### PR TITLE
Specify @envage/hapi-govuk-question-page module in frontend plugin

### DIFF
--- a/poc_flow_map_front_end/src/server/modules/hapi-govuk-question-page/page.njk
+++ b/poc_flow_map_front_end/src/server/modules/hapi-govuk-question-page/page.njk
@@ -1,1 +1,1 @@
-{% include "page-content.njk" %}
+{% include "hapi-govuk-question-page/page-content.njk" %}

--- a/poc_flow_map_front_end/src/server/plugins/frontend.js
+++ b/poc_flow_map_front_end/src/server/plugins/frontend.js
@@ -7,7 +7,10 @@ module.exports = {
     assetDirectories: ['public/static', 'public/build'],
     serviceName: 'Front end template demo',
     viewPath: 'src/server/modules',
-    includePaths: ['node_modules/@ministryofjustice/frontend'],
+    includePaths: [
+      'node_modules/@ministryofjustice/frontend',
+      'node_modules/@envage/hapi-govuk-question-page'
+    ],
     context: {
       appVersion: pkg.version
     }


### PR DESCRIPTION
This allows the inefficient node_modules crawl for nunjucks templates to be switched off when the paths are all specified.